### PR TITLE
RufflesSocket.Stop() throws on a running socket

### DIFF
--- a/Ruffles/Core/RuffleSocket.cs
+++ b/Ruffles/Core/RuffleSocket.cs
@@ -200,7 +200,7 @@ namespace Ruffles.Core
         /// </summary>
         public void Stop()
         {
-            if (IsRunning)
+            if (!IsRunning)
             {
                 throw new InvalidOperationException("Cannot stop a non running socket");
             }


### PR DESCRIPTION
I added the missing ! to the IsRunning check.

Note: Directly editing this on github unified line endings in the file to Windows Line Endings. 