### PR TITLE
Stop is now working on a Running socket.

### DIFF
--- a/Ruffles/Core/RuffleSocket.cs
+++ b/Ruffles/Core/RuffleSocket.cs
@@ -200,7 +200,7 @@ namespace Ruffles.Core
         /// </summary>
         public void Stop()
         {
-            if (IsRunning)
+            if (!IsRunning)
             {
                 throw new InvalidOperationException("Cannot stop a non running socket");
             }
@@ -208,6 +208,7 @@ namespace Ruffles.Core
             // Disconnect all clients
             for (int i = 0; i < connections.Length; i++)
             {
+                if(connections[i] == null) continue;
                 if (!connections[i].Dead && connections[i].State != ConnectionState.Disconnected)
                 {
                     connections[i].Disconnect(true);


### PR DESCRIPTION
I added a missing ! to the RufflesSocket.Stop() IsRunning check. Stop is no longer throwing a Cannot stop a non running socket on a running connection. 

Also added a null check during Disconnect all clients.

Note: Editing the file directly in github unified the line endings to Windows Line Endings, (might not be intended) 